### PR TITLE
package.json: Add `repository` to define VCS

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
         "name": "HERE Europe B.V.",
         "url": "https://here.com"
     },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/heremaps/harp-map-editor.git"
+    },
     "license": "Apache-2.0",
     "scripts": {
         "start": "webpack-dev-server -d",


### PR DESCRIPTION
Defining `repository` will enable tools like OSS Review Toolkit
to scan the source code of this package for licenses.
